### PR TITLE
Quit shell mode without error on Ctrl^D

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
     "fmt"
     "os"
+    "io"
     "strings"
     "strconv"
 )
@@ -38,6 +39,10 @@ func main() {
     for {
         text, err := term.ReadLine()
         if err != nil {
+            if err == io.EOF {
+              // Quit without error on Ctrl^D
+              break
+            }
             panic(err)
         }
 


### PR DESCRIPTION
So far Ctrl^D results in:

```
> panic: EOF

goroutine 1 [running]:
main.main()
	/home/leo/Projects/Go/src/github.com/alfredxing/calc/main.go:41 +0x618
```

This patch fixed that.