### PR TITLE
Have EOF insert a newline before returning

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 		if err != nil {
 			if err == io.EOF {
 				// Quit without error on Ctrl^D
+				fmt.Println()
 				break
 			}
 			panic(err)


### PR DESCRIPTION
Ctrl+D now leaves the shell prompt with `> ` before the prompt line