### PR TITLE
Wired linebreaks when using fmt.Print() functions in custom terminal

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,10 +58,10 @@ func main() {
 
 		res, err := compute.Evaluate(text)
 		if err != nil {
-			fmt.Println("Error: " + err.Error())
+			term.Write([]byte(fmt.Sprintln("Error: " + err.Error())))
 			continue
 		}
-		fmt.Printf("%s\n", strconv.FormatFloat(res, 'G', -1, 64))
+		term.Write([]byte(fmt.Sprintf("%s\n", strconv.FormatFloat(res, 'G', -1, 64))))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 			term.Write([]byte(fmt.Sprintln("Error: " + err.Error())))
 			continue
 		}
-		term.Write([]byte(fmt.Sprintf("%s\n", strconv.FormatFloat(res, 'G', -1, 64))))
+		term.Write([]byte(fmt.Sprintln(strconv.FormatFloat(res, 'G', -1, 64))))
 	}
 }
 


### PR DESCRIPTION
I have observed that using `fmt.Print()`, `fmt.Printf()`, `fmt.Println()` in a custom terminal often has some wired side effects. This isn't limited to this application, it is very easy to reproduce.

This PR just replaces the `Print`functions with `Sprint` and uses `term.Write()` to write to the terminal.

Below is a picture that shows the issue. First example was build from master branch, second was build from my fork with fixes:
![ohne titel](https://cloud.githubusercontent.com/assets/9931588/21594827/9dc39fd2-d127-11e6-8f5e-61a9133124d8.png)
